### PR TITLE
Add Basic Authentication

### DIFF
--- a/Spring-boot/.vscode/settings.json
+++ b/Spring-boot/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/Spring-boot/pom.xml
+++ b/Spring-boot/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
@@ -40,6 +45,7 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/Spring-boot/src/main/java/com/hactoberfest/config/SecurityConfig.java
+++ b/Spring-boot/src/main/java/com/hactoberfest/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.hactoberfest.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import com.hactoberfest.service.CustomUserDetailsService;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    private final CustomUserDetailsService customUserDetailsService;
+
+    public SecurityConfig(CustomUserDetailsService customUserDetailsService) {
+        this.customUserDetailsService = customUserDetailsService;
+    }
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(org.springframework.http.HttpMethod.POST, "/api/users").permitAll()
+                .anyRequest().authenticated()
+            )
+            .userDetailsService(customUserDetailsService)
+            .httpBasic(httpBasic -> {});
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/Spring-boot/src/main/java/com/hactoberfest/controller/UserController.java
+++ b/Spring-boot/src/main/java/com/hactoberfest/controller/UserController.java
@@ -2,6 +2,7 @@ package com.hactoberfest.controller;
 
 import com.hactoberfest.entity.User;
 import com.hactoberfest.service.UserService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,9 +14,11 @@ import java.util.Optional;
 @RequestMapping("/api/users")
 public class UserController {
     private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
 
-    public UserController(UserService userService) {
+    public UserController(UserService userService, PasswordEncoder passwordEncoder) {
         this.userService = userService;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @GetMapping
@@ -33,12 +36,14 @@ public class UserController {
 
     @PostMapping
     public ResponseEntity<User> createUser(@RequestBody User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
         User createdUser = userService.createUser(user);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<User> updateUser(@PathVariable Long id, @RequestBody User userDetails) {
+        userDetails.setPassword(passwordEncoder.encode(userDetails.getPassword()));
         User updatedUser = userService.updateUser(id, userDetails);
         if (updatedUser != null) {
             return ResponseEntity.ok(updatedUser);

--- a/Spring-boot/src/main/java/com/hactoberfest/entity/User.java
+++ b/Spring-boot/src/main/java/com/hactoberfest/entity/User.java
@@ -6,6 +6,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Data;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "users")
@@ -14,7 +17,14 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @NotBlank(message = "Username is required")
+    @Size(min = 3, max = 50, message = "Username must be between 3 and 50 characters")
     private String username;
+    @NotBlank(message = "Password is required")
+    @Size(min = 6, max = 100, message = "Password must be between 6 and 100 characters")
     private String password;
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email should be valid")
     private String email;
 }

--- a/Spring-boot/src/main/java/com/hactoberfest/repository/UserRepository.java
+++ b/Spring-boot/src/main/java/com/hactoberfest/repository/UserRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+	java.util.Optional<User> findByUsername(String username);
 }

--- a/Spring-boot/src/main/java/com/hactoberfest/service/CustomUserDetailsService.java
+++ b/Spring-boot/src/main/java/com/hactoberfest/service/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.hactoberfest.service;
+
+import com.hactoberfest.entity.User;
+import com.hactoberfest.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.User.UserBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+        UserBuilder builder = org.springframework.security.core.userdetails.User.withUsername(user.getUsername());
+        builder.password(user.getPassword());
+        builder.roles("USER");
+        return builder.build();
+    }
+}


### PR DESCRIPTION
#32 

Added Basic Authentication using Spring Security.

Key changes and new features:

Created SecurityConfig class for security configuration.

Defined a BCryptPasswordEncoder bean for secure password storage.

Implemented CustomUserDetails for loading user details.

Modified UserController to encrypt passwords before saving users.

Made the Create User API (POST /users) publicly accessible.

Secured all other API endpoints, requiring authentication.
