### PR TITLE
Add input validation for user endpoints

### DIFF
--- a/Spring-boot/pom.xml
+++ b/Spring-boot/pom.xml
@@ -26,10 +26,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -39,6 +35,10 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/Spring-boot/src/main/java/com/hactoberfest/controller/UserController.java
+++ b/Spring-boot/src/main/java/com/hactoberfest/controller/UserController.java
@@ -47,6 +47,16 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<String> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        StringBuilder errors = new StringBuilder();
+        ex.getBindingResult().getFieldErrors().forEach(error -> {
+            errors.append(error.getField()).append(": ").append(error.getDefaultMessage()).append("; ");
+        });
+        return ResponseEntity.badRequest().body(errors.toString());
+    }
+
     @PutMapping("/{id}")
     public ResponseEntity<User> updateUser(@PathVariable Long id, @Valid @RequestBody User userDetails) {
         userDetails.setPassword(passwordEncoder.encode(userDetails.getPassword()));
@@ -58,15 +68,7 @@ public class UserController {
         }
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ResponseEntity<String> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        StringBuilder errors = new StringBuilder();
-        ex.getBindingResult().getFieldErrors().forEach(error -> {
-            errors.append(error.getField()).append(": ").append(error.getDefaultMessage()).append("; ");
-        });
-        return ResponseEntity.badRequest().body(errors.toString());
-    }
+
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteUser(@PathVariable Long id) {


### PR DESCRIPTION
#33 

Added validation for User entity fields to ensure proper data before saving to the database.

Key changes:

Applied validation annotations in the User entity:

@NotBlank for username and password

@Email for email

@Size constraints where required

Updated UserController methods to use @Valid on request bodies.

Ensured invalid inputs return proper error responses with validation messages.
