### PR TITLE
fix(auth): Fix incorrect redirect after successful login

### DIFF
--- a/Larvel_aiPostJob/app/Http/Controllers/Auth/LoginController.php
+++ b/Larvel_aiPostJob/app/Http/Controllers/Auth/LoginController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request; // <-- 1. ADD THIS IMPORT STATEMENT
 
 class LoginController extends Controller
 {
@@ -36,5 +37,32 @@ class LoginController extends Controller
     {
         $this->middleware('guest')->except('logout');
         $this->middleware('auth')->only('logout');
+    }
+
+    // 2. ADD THIS ENTIRE FUNCTION TO THE CLASS
+    /**
+     * The user has been authenticated. This method is called by the AuthenticatesUsers trait.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $user
+     * @return mixed
+     */
+    protected function authenticated(Request $request, $user)
+    {
+        // Check the user's role and redirect to the appropriate dashboard
+        switch ($user->role) {
+            case 'admin':
+                return redirect()->route('admin.dashboard');
+            case 'company':
+                return redirect()->route('company.jobs');
+            case 'freelancer':
+                return redirect()->route('freelancer.profile');
+            case 'client':
+                return redirect()->route('client.projects');
+            default:
+                // If the user has no specific role, or a role without a dashboard,
+                // send them to the default home page.
+                return redirect($this->redirectTo);
+        }
     }
 }


### PR DESCRIPTION
Closes #65

## What this PR does
This PR fixes a bug where users were being redirected back to the login page even after a successful login.

The issue was caused by the `LoginController` redirecting all users to the public homepage (`/home`), which does not have authentication middleware.

## The Solution
I have implemented the `authenticated()` method in the `LoginController`. This method checks the user's role immediately after they log in and redirects them to their appropriate role-based dashboard (e.g., `/admin/dashboard`, `/company/jobs`, etc.), which are correctly protected by the `auth` middleware.

This ensures a correct and secure post-login user experience.